### PR TITLE
security: set npmMinimalAgeGate to 7d

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,8 @@ nodeLinker: node-modules
 
 nmSelfReferences: false
 
+npmMinimalAgeGate: 7d
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
     spec: "@yarnpkg/plugin-workspace-tools"


### PR DESCRIPTION
## Summary
Sets `npmMinimalAgeGate: 7d` in `.yarnrc.yml` to prevent Yarn from installing npm packages published less than 7 days ago.

This is a defence against supply chain worm attacks (Shai-Hulud, Sept 2025 / Glassworm 2026) that inject malicious post-install scripts into newly published popular packages.

Part of org-wide security hardening across all Yarn Berry repos.